### PR TITLE
Compile errors under MinGW and MSVC2008 and the patchs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DI
 # build settings
 include_directories(src src/simgear/xml)
 add_definitions(-DHAVE_EXPAT_CONFIG_H)
+if (MSVC)
+    add_definitions(-D_USE_MATH_DEFINES)
+endif()
 
 install(FILES
     src/math/FGColumnVector3.h
@@ -319,7 +322,7 @@ install(FILES
     )
 
 # jsbsim library
-add_library(jsbsim 
+add_library(libjsbsim 
     src/input_output/FGfdmSocket.cpp
     src/input_output/FGXMLParse.cpp
     src/input_output/FGScript.cpp
@@ -413,14 +416,22 @@ add_library(jsbsim
     src/FGFDMExec.cpp
     src/FGJSBBase.cpp
     )
-target_link_libraries(jsbsim m)
-install(TARGETS jsbsim DESTINATION lib)
+# Remove prefix 'lib' in any platform
+set_target_properties(libjsbsim PROPERTIES PREFIX "")
+if(NOT MSVC)
+    target_link_libraries(libjsbsim m)
+endif()
+if(MINGW)
+    find_library(WSOCK32 NAMES wsock32 ws2_32)
+    target_link_libraries(libjsbsim ${WSOCK32})
+endif()
+install(TARGETS libjsbsim DESTINATION lib)
 
 # jsbsim executable
 add_executable(JSBSim
     src/JSBSim.cpp
     )
-target_link_libraries(JSBSim jsbsim)
+target_link_libraries(JSBSim libjsbsim)
 install(TARGETS JSBSim DESTINATION bin)
 
 # jsbsim gui

--- a/src/initialization/FGTrimmer.cpp
+++ b/src/initialization/FGTrimmer.cpp
@@ -29,7 +29,7 @@
 #include <iomanip>
 #include <cstdlib>
 #include <stdexcept>
-#include <inttypes.h>
+#include "simgear/misc/stdint.hxx"
 
 namespace JSBSim
 {

--- a/src/math/FGStateSpace.cpp
+++ b/src/math/FGStateSpace.cpp
@@ -100,6 +100,7 @@ std::ostream &operator<<( std::ostream &out, const FGStateSpace::Component &c )
     out << "\t" << c.getName()
     << "\t" << c.getUnit()
     << "\t:\t" << c.get();
+    return out;
 }
 
 std::ostream &operator<<( std::ostream &out, const FGStateSpace::ComponentVector &v )
@@ -109,6 +110,7 @@ std::ostream &operator<<( std::ostream &out, const FGStateSpace::ComponentVector
         out << *(v.getComp(i)) << "\n";
     }
     out << "";
+    return out;
 }
 
 std::ostream &operator<<( std::ostream &out, const FGStateSpace &ss )
@@ -116,6 +118,7 @@ std::ostream &operator<<( std::ostream &out, const FGStateSpace &ss )
     out << "\nX:\n" << ss.x
     << "\nU:\n" << ss.u
     << "\nY:\n" << ss.y;
+    return out;
 }
 
 std::ostream &operator<<( std::ostream &out, const std::vector< std::vector<double> > &vec2d )
@@ -142,6 +145,7 @@ std::ostream &operator<<( std::ostream &out, const std::vector< std::vector<doub
         }
         out << std::flush;
     }
+    return out;
 }
 
 std::ostream &operator<<( std::ostream &out, const std::vector<double> &vec )
@@ -158,6 +162,7 @@ std::ostream &operator<<( std::ostream &out, const std::vector<double> &vec )
         else out <<  ";\n";
     }
     out << std::flush;
+    return out;
 }
 
 


### PR DESCRIPTION
Change the name of library jsbsim to avoid names conflict because of ignorecase filename on MS Windows.
Link library libwsock32.a in MinGW platform.
Avoid linking libm.a in MSVC platform.
Define _USE_MATH_DEFINES to enable math constants in MSVC platform.

Return the missing reference "out" in operator functions in src/math/FGStateSpace.cpp.

Patchs are tested in both MinGW and MSVC2008. And test with the command "bin\JSBSim.exe --root=share\jsbsim --script=scripts/737_cruise_steady_turn_simplex.xml". MSVC2008's app works well.

But MinGW's app fails when outputing the linearization matrix ABCD.
